### PR TITLE
added missing gqlSchema to recursive resolveVariableType function

### DIFF
--- a/lib/assets/gql-generator.js
+++ b/lib/assets/gql-generator.js
@@ -1,7 +1,6 @@
 // Forked from https://github.com/timqian/gql-generator.
 
-var graphql = require('graphql'),
-
+var graphql = require("graphql"),
   /**
    * Generate variables string
    *
@@ -9,29 +8,28 @@ var graphql = require('graphql'),
    */
   getArgsToVarsStr = (dict) => {
     return Object.entries(dict)
-      .map(([varName, arg]) => { return `${arg.name}: $${varName}`; })
-      .join(', ');
+      .map(([varName, arg]) => {
+        return `${arg.name}: $${varName}`;
+      })
+      .join(", ");
   },
-
   /**
    * Sanitizes type i.e. Removes '!' and '[]'
    *
    * @param {object} type GraphQL type
    */
   getTypeFromTypeObject = (type) => {
-    const scalarTypes = ['String', 'ID', 'Boolean'];
+    const scalarTypes = ["String", "ID", "Boolean"];
     type = type.toString();
 
     if (scalarTypes.includes(type)) {
       return type;
-    }
-    else if (type.includes('[')) {
-      type = type.split('[')[1].split(']')[0];
+    } else if (type.includes("[")) {
+      type = type.split("[")[1].split("]")[0];
     }
 
-    return type.split('!')[0];
+    return type.split("!")[0];
   },
-
   /**
    * Returns default for a particular type
    *
@@ -39,25 +37,24 @@ var graphql = require('graphql'),
    */
   getDefaultForType = (type) => {
     switch (type) {
-      case 'String':
-        return '';
-      case 'Int':
+      case "String":
+        return "";
+      case "Int":
         return 0;
-      case 'Int!':
+      case "Int!":
         return 0;
-      case 'Boolean':
+      case "Boolean":
         return true;
-      case 'ID':
+      case "ID":
         return 0;
-      case 'object':
+      case "object":
         return {};
-      case '[]':
+      case "[]":
         return [];
       default:
-        return '';
+        return "";
     }
   },
-
   /**
    * Generate types string
    *
@@ -68,7 +65,7 @@ var graphql = require('graphql'),
       .map(([varName, arg]) => {
         return `$${varName}: ${arg.type}`;
       })
-      .join(', ');
+      .join(", ");
   };
 
 /**
@@ -78,7 +75,7 @@ var graphql = require('graphql'),
  * @param duplicateArgCounts map for deduping argument name collisions
  * @param allArgsDict dictionary of all arguments
  */
-function getFieldArgsDict (field, duplicateArgCounts, allArgsDict = {}) {
+function getFieldArgsDict(field, duplicateArgCounts, allArgsDict = {}) {
   return field.args.reduce((argumentDict, arg) => {
     if (arg.name in duplicateArgCounts) {
       const index = duplicateArgCounts[arg.name] + 1;
@@ -89,8 +86,7 @@ function getFieldArgsDict (field, duplicateArgCounts, allArgsDict = {}) {
     else if (allArgsDict[arg.name]) {
       duplicateArgCounts[arg.name] = 1;
       argumentDict[`${arg.name}1`] = arg;
-    }
-    else {
+    } else {
       argumentDict[arg.name] = arg;
     }
     return argumentDict;
@@ -102,23 +98,23 @@ function getFieldArgsDict (field, duplicateArgCounts, allArgsDict = {}) {
  * @param {object} type
  * @param {object} gqlSchema
  */
-function resolveVariableType (type, gqlSchema) {
+function resolveVariableType(type, gqlSchema) {
   var fieldObj = {},
     fields;
   const argType = gqlSchema.getType(getTypeFromTypeObject(type));
   if (graphql.isInputObjectType(argType)) {
     fields = argType.getFields();
     Object.keys(fields).forEach((field) => {
-      if (type.toString().includes('[') && type.toString().includes(']')) {
-        fieldObj[field] = [resolveVariableType(fields[field].type)];
+      if (type.toString().includes("[") && type.toString().includes("]")) {
+        fieldObj[field] = [resolveVariableType(fields[field].type, gqlSchema)];
       }
-      fieldObj[field] = resolveVariableType(fields[field].type);
+      fieldObj[field] = resolveVariableType(fields[field].type, gqlSchema);
     });
     return fieldObj;
   }
-  return type.toString().includes('[') ?
-    [getDefaultForType(argType.toString())] :
-    getDefaultForType(argType.toString());
+  return type.toString().includes("[")
+    ? [getDefaultForType(argType.toString())]
+    : getDefaultForType(argType.toString());
 }
 
 module.exports = {
@@ -128,7 +124,7 @@ module.exports = {
    * @param {Integer} depthLimit - Depth of nodes to be populated in the query.
    * @param {Boolean} includeDeprecatedFields - Deprecated fields to be included or not.
    */
-  schemaToQuery (gqlSchema, depthLimit = 1, includeDeprecatedFields = false) {
+  schemaToQuery(gqlSchema, depthLimit = 1, includeDeprecatedFields = false) {
     const output = {};
 
     /**
@@ -142,74 +138,100 @@ module.exports = {
      * @param crossReferenceKeyList list of the cross reference
      * @param curDepth current depth of field
      */
-    function generateQuery (
+    function generateQuery(
       curName,
       curParentType,
       curParentName,
       argumentsDict = {},
       duplicateArgCounts = {},
       crossReferenceKeyList = [], // [`${curParentName}To${curName}Key`]
-      curDepth = 1) {
+      curDepth = 1
+    ) {
       const field = gqlSchema.getType(curParentType).getFields()[curName],
-        curTypeName = field.type.inspect().replace(/[[\]!]/g, ''),
+        curTypeName = field.type.inspect().replace(/[[\]!]/g, ""),
         curType = gqlSchema.getType(curTypeName);
-      let queryStr = '',
-        childQuery = '';
+      let queryStr = "",
+        childQuery = "";
 
       if (curType.getFields) {
         const crossReferenceKey = `${curParentName}To${curName}Key`;
-        if (crossReferenceKeyList.includes(crossReferenceKey) || curDepth > depthLimit) {
-          return '';
+        if (
+          crossReferenceKeyList.includes(crossReferenceKey) ||
+          curDepth > depthLimit
+        ) {
+          return "";
         }
         crossReferenceKeyList.push(crossReferenceKey);
         let childKeys = Object.keys(curType.getFields());
         childQuery = childKeys
           .filter((fieldName) => {
             /* Exclude deprecated fields */
-            const fieldSchema = gqlSchema.getType(curType).getFields()[fieldName];
+            const fieldSchema = gqlSchema.getType(curType).getFields()[
+              fieldName
+            ];
             return includeDeprecatedFields || !fieldSchema.isDeprecated;
           })
           .map((cur) => {
-            return generateQuery(cur, curType, curName, argumentsDict, duplicateArgCounts,
-              crossReferenceKeyList, curDepth + 1).queryStr;
+            return generateQuery(
+              cur,
+              curType,
+              curName,
+              argumentsDict,
+              duplicateArgCounts,
+              crossReferenceKeyList,
+              curDepth + 1
+            ).queryStr;
           })
           .filter((cur) => {
             return cur;
           })
-          .join('\n');
+          .join("\n");
       }
 
       if (!(curType.getFields && !childQuery)) {
-        queryStr = `${'    '.repeat(curDepth)}${field.name}`;
+        queryStr = `${"    ".repeat(curDepth)}${field.name}`;
         if (field.args.length > 0) {
-          const dict = getFieldArgsDict(field, duplicateArgCounts, argumentsDict);
+          const dict = getFieldArgsDict(
+            field,
+            duplicateArgCounts,
+            argumentsDict
+          );
           Object.assign(argumentsDict, dict);
 
           queryStr += ` (${getArgsToVarsStr(dict)})`;
         }
         if (childQuery) {
-          queryStr += ` {\n${childQuery}\n${'    '.repeat(curDepth)}}`;
+          queryStr += ` {\n${childQuery}\n${"    ".repeat(curDepth)}}`;
         }
       }
 
       /* Union types */
-      if (curType.astNode && curType.astNode.kind === 'UnionTypeDefinition') {
+      if (curType.astNode && curType.astNode.kind === "UnionTypeDefinition") {
         const types = curType.getTypes();
         if (types && types.length) {
-          const indent = `${'    '.repeat(curDepth)}`,
-            fragIndent = `${'    '.repeat(curDepth + 1)}`;
-          queryStr += ' {\n';
+          const indent = `${"    ".repeat(curDepth)}`,
+            fragIndent = `${"    ".repeat(curDepth + 1)}`;
+          queryStr += " {\n";
 
           for (let i = 0, len = types.length; i < len; i++) {
             const valueTypeName = types[i],
               valueType = gqlSchema.getType(valueTypeName),
               unionChildQuery = Object.keys(valueType.getFields())
                 .map((cur) => {
-                  return generateQuery(cur, valueType, curName, argumentsDict, duplicateArgCounts,
-                    crossReferenceKeyList, curDepth + 2).queryStr;
+                  return generateQuery(
+                    cur,
+                    valueType,
+                    curName,
+                    argumentsDict,
+                    duplicateArgCounts,
+                    crossReferenceKeyList,
+                    curDepth + 2
+                  ).queryStr;
                 })
-                .filter((cur) => { return cur; })
-                .join('\n');
+                .filter((cur) => {
+                  return cur;
+                })
+                .join("\n");
 
             queryStr += `${fragIndent}... on ${valueTypeName} {\n${unionChildQuery}\n${fragIndent}}\n`;
           }
@@ -225,21 +247,21 @@ module.exports = {
      * @param obj one of the root objects(Query, Mutation, Subscription)
      * @param description description of the current object
      */
-    function generateQueries (obj, description) {
+    function generateQueries(obj, description) {
       let currentObject = {},
         outputFolderName;
       switch (description) {
-        case 'Mutation':
-          outputFolderName = 'mutations';
+        case "Mutation":
+          outputFolderName = "mutations";
           break;
-        case 'Query':
-          outputFolderName = 'queries';
+        case "Query":
+          outputFolderName = "queries";
           break;
-        case 'Subscription':
-          outputFolderName = 'subscriptions';
+        case "Subscription":
+          outputFolderName = "subscriptions";
           break;
         default:
-          console.log('[gqlg warning]:', 'description is required');
+          console.log("[gqlg warning]:", "description is required");
       }
 
       Object.keys(obj).forEach((type) => {
@@ -257,10 +279,12 @@ module.exports = {
           });
 
           let query = queryResult.queryStr;
-          query = `${description.toLowerCase()} ${type}${varsToTypesStr ? ` (${varsToTypesStr}) ` : ' '}{\n${query}\n}`;
+          query = `${description.toLowerCase()} ${type}${
+            varsToTypesStr ? ` (${varsToTypesStr}) ` : " "
+          }{\n${query}\n}`;
           currentObject[type] = {
             query: query,
-            variables: JSON.stringify(variables, null, 2)
+            variables: JSON.stringify(variables, null, 2),
           };
         }
       });
@@ -268,17 +292,20 @@ module.exports = {
     }
 
     if (gqlSchema.getMutationType()) {
-      generateQueries(gqlSchema.getMutationType().getFields(), 'Mutation');
+      generateQueries(gqlSchema.getMutationType().getFields(), "Mutation");
     }
 
     if (gqlSchema.getQueryType()) {
-      generateQueries(gqlSchema.getQueryType().getFields(), 'Query');
+      generateQueries(gqlSchema.getQueryType().getFields(), "Query");
     }
 
     if (gqlSchema.getSubscriptionType()) {
-      generateQueries(gqlSchema.getSubscriptionType().getFields(), 'Subscription');
+      generateQueries(
+        gqlSchema.getSubscriptionType().getFields(),
+        "Subscription"
+      );
     }
 
     return output;
-  }
+  },
 };


### PR DESCRIPTION
This pull request fixes issues with resolving graphql's input type. Before it was failing with the reason `"Could not generate collection. Error Message:Cannot read property 'getType' of undefined` when you tried something like

```
type Foo {
    id: String
}

input Foo_Input {
    id: String
}

type Mutation {
    CreateFoo(input: Foo_Input): Foo
}
```

With the fix everything works as expected and you'll be able to generate collections when you have an input type defined in your schema!