### PR TITLE
Fix for circular input object references

### DIFF
--- a/lib/assets/gql-generator.js
+++ b/lib/assets/gql-generator.js
@@ -101,18 +101,26 @@ function getFieldArgsDict (field, duplicateArgCounts, allArgsDict = {}) {
  *
  * @param {object} type
  * @param {object} gqlSchema
+ * @param {Number} stack
  */
-function resolveVariableType (type, gqlSchema) {
+function resolveVariableType (type, gqlSchema, stack = 0) {
   var fieldObj = {},
+    stackLimit = 10,
     fields;
+  stack++;
   const argType = gqlSchema.getType(getTypeFromTypeObject(type));
   if (graphql.isInputObjectType(argType)) {
     fields = argType.getFields();
     Object.keys(fields).forEach((field) => {
-      if (type.toString().includes('[') && type.toString().includes(']')) {
-        fieldObj[field] = [resolveVariableType(fields[field].type, gqlSchema)];
+      if (fields[field].type === type) {
+        fieldObj[field] = 'Same as ' + type;
       }
-      fieldObj[field] = resolveVariableType(fields[field].type, gqlSchema);
+      else if (stack <= stackLimit) {
+        if (type.toString().includes('[') && type.toString().includes(']')) {
+          fieldObj[field] = [resolveVariableType(fields[field].type, gqlSchema, stack)];
+        }
+        fieldObj[field] = resolveVariableType(fields[field].type, gqlSchema, stack);
+      }
     });
     return fieldObj;
   }

--- a/lib/assets/gql-generator.js
+++ b/lib/assets/gql-generator.js
@@ -113,7 +113,7 @@ function resolveVariableType (type, gqlSchema, stack = 0) {
     fields = argType.getFields();
     Object.keys(fields).forEach((field) => {
       if (fields[field].type === type) {
-        fieldObj[field] = 'Same as ' + type;
+        fieldObj[field] = '<Same as ' + type + '>';
       }
       else if (stack <= stackLimit) {
         if (type.toString().includes('[') && type.toString().includes(']')) {

--- a/test/unit/converter.test.js
+++ b/test/unit/converter.test.js
@@ -8,6 +8,7 @@ var converter = require('../../index'),
   invalidSchemaJson = require('./fixtures/invalidSchema.json'),
   validSchemaSDL = fs.readFileSync(path.join(__dirname, './fixtures/validSchemaSDL.graphql')).toString(),
   issue10 = fs.readFileSync(path.join(__dirname, './fixtures/issue#10.graphql')).toString(),
+  circularInput = fs.readFileSync(path.join(__dirname, './fixtures/circularInput.graphql')).toString(),
   invalidSchemaSDL = fs.readFileSync(path.join(__dirname, './fixtures/invalidSchemaSDL.graphql')).toString(),
   expect = require('chai').expect;
 
@@ -89,6 +90,19 @@ describe('Converter tests', function () {
         expect(collection.item[0].item[0].request.body.graphql.query).to.be.equal('mutation addUser ' +
         '($input: UserInput) {\n    addUser (input: $input) {\n        id\n        name\n    }\n}');
 
+        return done();
+      });
+    });
+
+    it('should successfully convert a schema with circular reference', function (done) {
+      convert({ type: 'string',
+        data: circularInput
+      }, {}, function (error, result) {
+        if (error) {
+          expect.fail(null, null, error);
+          return done();
+        }
+        expect(result.result).to.be.equal(true);
         return done();
       });
     });

--- a/test/unit/converter.test.js
+++ b/test/unit/converter.test.js
@@ -102,7 +102,12 @@ describe('Converter tests', function () {
           expect.fail(null, null, error);
           return done();
         }
+        const collection = result.output[0].data;
+
         expect(result.result).to.be.equal(true);
+        expect(collection.item[0].item[0].request.body.graphql.variables).to.contain('"name": "",\n      "email": "",' +
+        '\n      "friend": "<Same as UserInput!>"');
+
         return done();
       });
     });

--- a/test/unit/fixtures/circularInput.graphql
+++ b/test/unit/fixtures/circularInput.graphql
@@ -1,0 +1,19 @@
+schema {
+  query: Query
+  mutation: Mutation
+}
+input UserInput {
+  name: String!
+  email: String!
+  friend: UserInput!
+}
+type User {
+  id: String!
+  name: String
+}
+type Query {
+  user (id: String): User
+}
+type Mutation {
+  addUser (input: UserInput): User!
+}


### PR DESCRIPTION
Here is a hypothetical example of a Circular Input Object type.

```
input CreateUserInput { 
  username: String!
  firstname: String!
  lastname: String!
  manager: CreateUserInput!
}
```
This is causing the importer to crash with `Maximum call stack size exceeded error`. 

This PR fixes this issue.