### PR TITLE
Fix an error - Cannot read 'getFields()' of undefined.

### DIFF
--- a/lib/assets/gql-generator.js
+++ b/lib/assets/gql-generator.js
@@ -271,9 +271,6 @@ module.exports = {
           field = gqlSchema._subscriptionType._fields[type];
           newDescription = gqlSchema._subscriptionType.name;
         }
-        else {
-          throw new Error('Only Mutation, Query, and Subscription are supported currently');
-        }
 
         /* Only process non-deprecated queries/mutations: */
         if (includeDeprecatedFields || !field.isDeprecated) {

--- a/lib/assets/gql-generator.js
+++ b/lib/assets/gql-generator.js
@@ -158,6 +158,7 @@ module.exports = {
       duplicateArgCounts = {},
       crossReferenceKeyList = [], // [`${curParentName}To${curName}Key`]
       curDepth = 1) {
+
       const field = gqlSchema.getType(curParentType).getFields()[curName],
         curTypeName = field.type.inspect().replace(/[[\]!]/g, ''),
         curType = gqlSchema.getType(curTypeName);
@@ -251,11 +252,32 @@ module.exports = {
       }
 
       Object.keys(obj).forEach((type) => {
-        const field = gqlSchema.getType(description).getFields()[type];
+
+        let field,
+          newDescription;
+
+        // The name of the mutationType can be anything other than 'Mutation'
+        // Handle for each type separately and use the new description to traverse through
+        // the fields.
+        if (description === 'Mutation') {
+          field = gqlSchema._mutationType._fields[type];
+          newDescription = gqlSchema._mutationType.name;
+        }
+        else if (description === 'Query') {
+          field = gqlSchema._queryType._fields[type];
+          newDescription = gqlSchema._queryType.name;
+        }
+        else if (description === 'Subscription') {
+          field = gqlSchema._subscriptionType._fields[type];
+          newDescription = gqlSchema._subscriptionType.name;
+        }
+        else {
+          throw new Error('Only Mutation, Query, and Subscription are supported currently');
+        }
 
         /* Only process non-deprecated queries/mutations: */
         if (includeDeprecatedFields || !field.isDeprecated) {
-          const queryResult = generateQuery(type, description),
+          const queryResult = generateQuery(type, newDescription),
             varsToTypesStr = getVarsToTypesStr(queryResult.argumentsDict);
 
           /* Generate variables Object from argumentDict */
@@ -265,6 +287,8 @@ module.exports = {
           });
 
           let query = queryResult.queryStr;
+          // here the `description` is used to construct the actual queries
+          // Here has to be one of query, mutation, or subscription.
           query = `${description.toLowerCase()} ${type}${varsToTypesStr ? ` (${varsToTypesStr}) ` : ' '}{\n${query}\n}`;
           currentObject[type] = {
             query: query,

--- a/test/unit/converter.test.js
+++ b/test/unit/converter.test.js
@@ -7,6 +7,7 @@ var converter = require('../../index'),
   validSchemaJson = require('./fixtures/validSchema.json'),
   invalidSchemaJson = require('./fixtures/invalidSchema.json'),
   validSchemaSDL = fs.readFileSync(path.join(__dirname, './fixtures/validSchemaSDL.graphql')).toString(),
+  customTypeNames = fs.readFileSync(path.join(__dirname, './fixtures/custom-queryname.gql')).toString(),
   issue10 = fs.readFileSync(path.join(__dirname, './fixtures/issue#10.graphql')).toString(),
   circularInput = fs.readFileSync(path.join(__dirname, './fixtures/circularInput.graphql')).toString(),
   invalidSchemaSDL = fs.readFileSync(path.join(__dirname, './fixtures/invalidSchemaSDL.graphql')).toString(),
@@ -65,7 +66,6 @@ describe('Converter tests', function () {
           return done();
         }
         const collection = result.output[0].data;
-
         expect(collection.item[0].item[0].request.body.mode).to.be.equal('graphql');
         expect(collection.item[0].item[0].request.body.graphql).to.be.an('object');
         expect(collection.item[0].item[0].request.body.graphql.query).to.be.a('string');
@@ -102,6 +102,39 @@ describe('Converter tests', function () {
         expect(collection.item[0].item[0].request.body.graphql.variables).to.be.equal(
           '{\n  "launchIds": [\n    0\n  ]\n}'
         );
+
+        return done();
+      });
+    });
+
+    it('should generate a collection for a valid SDL schema with custom query, mutation and' +
+    'subscription names', function (done) {
+      convert({ type: 'string',
+        data: customTypeNames
+      }, {}, function (error, result) {
+        if (error) {
+          expect.fail(null, null, error);
+          return done();
+        }
+        const collection = result.output[0].data;
+        fs.writeFileSync('hello.json', JSON.stringify(collection, null, 2));
+
+        expect(collection.item[0].item[0].request.body.mode).to.be.equal('graphql');
+        expect(collection.item[0].item[0].request.body.graphql).to.be.an('object');
+        expect(collection.item[0].item[0].request.body.graphql.query).to.be.a('string');
+        expect(collection.item[0].item[0].request.body.graphql.query).to.be.equal(
+          'mutation addUser ($input: UserInput) {\n    addUser (input: $input) {\n        id\n        name\n    }\n}'
+        );
+        expect(collection.item[1].item[0].request.body.graphql.query).to.be.equal(
+          'query user ($id: String) {\n    user (id: $id) {\n        id\n        name\n    }\n}'
+        );
+        expect(collection.item[2].item[0].request.body.graphql.query).to.be.equal(
+          'subscription addUser ($input: UserInput) {\n    addUser (input: $input) ' +
+          '{\n        id\n        name\n    }\n}'
+        );
+        expect(collection.item[0].item[0].request.body.graphql.variables).to.be.a('string');
+        expect(collection.item[1].item[0].request.body.graphql.variables).to.be.a('string');
+        expect(collection.item[2].item[0].request.body.graphql.variables).to.be.a('string');
 
         return done();
       });

--- a/test/unit/converter.test.js
+++ b/test/unit/converter.test.js
@@ -117,7 +117,6 @@ describe('Converter tests', function () {
           return done();
         }
         const collection = result.output[0].data;
-        fs.writeFileSync('hello.json', JSON.stringify(collection, null, 2));
 
         expect(collection.item[0].item[0].request.body.mode).to.be.equal('graphql');
         expect(collection.item[0].item[0].request.body.graphql).to.be.an('object');

--- a/test/unit/fixtures/custom-queryname.gql
+++ b/test/unit/fixtures/custom-queryname.gql
@@ -1,0 +1,23 @@
+schema {
+  query: RandomQueryName
+  mutation: RandomMutationName
+  subscription: RandomSubscriptionName
+}
+input UserInput {
+  name: String!
+  email: String!
+}
+type User {
+  id: String!
+  name: String
+}
+type RandomQueryName {
+  user (id: String): User
+}
+type RandomMutationName {
+  addUser (input: UserInput): User!
+}
+
+type RandomSubscriptionName {
+  addUser (input: UserInput): User!
+}


### PR DESCRIPTION
The error was happening due to custom names provided in the schema for query/mutation/subscription. 

There were not handled previously due to which the error was seen. This PR respects the custom name provided in the schema object and uses that to determine the fields.