### PR TITLE
Fixed issue where conversion failed with type error while resolving non-defined variables.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Tests
+
+on:
+  [pull_request]
+
+jobs:
+  Unit-Tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - run: npm ci
+      - run: npm run test

--- a/lib/assets/gql-generator.js
+++ b/lib/assets/gql-generator.js
@@ -30,7 +30,7 @@ var graphql = require('graphql'),
    */
   getTypeFromTypeObject = (type) => {
     const scalarTypes = ['String', 'ID', 'Boolean'];
-    type = type.toString();
+    type = _.toString(type);
 
     let matchedType;
 
@@ -146,7 +146,9 @@ function resolveVariableType (type, gqlSchema, stack = 0, stackLimit = 5) {
   var fieldObj = {},
     fields;
   stack++;
-  const argType = gqlSchema.getType(getTypeFromTypeObject(type));
+  const argType = gqlSchema.getType(getTypeFromTypeObject(type)),
+    typeString = _.toString(type);
+
   if (graphql.isInputObjectType(argType)) {
     fields = argType.getFields();
     Object.keys(fields).forEach((field) => {
@@ -154,7 +156,7 @@ function resolveVariableType (type, gqlSchema, stack = 0, stackLimit = 5) {
         fieldObj[field] = '<Same as ' + type + '>';
       }
       else if (stack <= stackLimit) {
-        if (type.toString().includes('[') && type.toString().includes(']')) {
+        if (typeString.includes('[') && typeString.includes(']')) {
           fieldObj[field] = [resolveVariableType(fields[field].type, gqlSchema, stack, stackLimit)];
         }
         fieldObj[field] = resolveVariableType(fields[field].type, gqlSchema, stack, stackLimit);
@@ -164,10 +166,10 @@ function resolveVariableType (type, gqlSchema, stack = 0, stackLimit = 5) {
   }
 
   // If type is an array, get the default value for the type and return the desired depth nested array
-  if (type.toString().includes('[')) {
-    const defaultForType = getDefaultForType(argType.toString());
+  if (typeString.includes('[')) {
+    const defaultForType = getDefaultForType(_.toString(argType));
 
-    let depth = getDepthOfArray(type.toString()),
+    let depth = getDepthOfArray(typeString),
       result = defaultForType;
 
     // Create nested array w.r.t the depth of type
@@ -179,7 +181,7 @@ function resolveVariableType (type, gqlSchema, stack = 0, stackLimit = 5) {
     return result;
   }
 
-  return getDefaultForType(argType.toString());
+  return getDefaultForType(_.toString(argType));
 }
 
 module.exports = {

--- a/test/unit/gql-generator.test.js
+++ b/test/unit/gql-generator.test.js
@@ -1,0 +1,25 @@
+const schemaToQuery = require('../../lib/assets/gql-generator').schemaToQuery,
+  fs = require('fs'),
+  path = require('path'),
+  graphql = require('graphql'),
+  validSchemaSDL = fs.readFileSync(path.join(__dirname, './fixtures/validSchemaSDL.graphql')).toString(),
+  expect = require('chai').expect;
+
+describe('gql-generator tests', function () {
+  it('should not throw type error for non defined elements in GQL schema', function (done) {
+    const data = validSchemaSDL,
+      gqlSchemaObj = graphql.buildSchema(data);
+
+    // Set specific property as null to test behaviour for non defined nodes.
+    gqlSchemaObj._typeMap.PatchSize = undefined;
+
+    try {
+      schemaToQuery(gqlSchemaObj, { depth: 5 });
+    }
+    catch (e) {
+      expect(e).to.be.undefined;
+    }
+
+    done();
+  });
+});


### PR DESCRIPTION
This PR adds support for resolving non-defined variables gracefully without throwing type error by using safer `_.toString()` instead of direct `.toString()` function.