### PR TITLE
Fixed issue where gql-generator was not handling non object types correctly.

### DIFF
--- a/lib/assets/gql-generator.js
+++ b/lib/assets/gql-generator.js
@@ -18,6 +18,10 @@ var graphql = require('graphql'),
    * @param dict dictionary of arguments
    */
   getArgsToVarsStr = (dict) => {
+    if (typeof dict !== 'object') {
+      return '';
+    }
+
     return Object.entries(dict)
       .map(([varName, arg]) => { return `${arg.name}: $${varName}`; })
       .join(', ');
@@ -102,6 +106,10 @@ var graphql = require('graphql'),
    * @param dict dictionary of arguments
    */
   getVarsToTypesStr = (dict) => {
+    if (typeof dict !== 'object') {
+      return '';
+    }
+
     return Object.entries(dict)
       .map(([varName, arg]) => {
         return `$${varName}: ${arg.type}`;
@@ -151,7 +159,7 @@ function resolveVariableType (type, gqlSchema, stack = 0, stackLimit = 4) {
 
   if (graphql.isInputObjectType(argType)) {
     fields = argType.getFields();
-    Object.keys(fields).forEach((field) => {
+    typeof fields === 'object' && Object.keys(fields).forEach((field) => {
       if (fields[field].type === type) {
         fieldObj[field] = '<Same as ' + type + '>';
       }
@@ -241,7 +249,7 @@ module.exports = {
         }
         crossReferenceKeyList[crossReferenceKey] = true;
 
-        let childKeys = Object.keys(curType.getFields());
+        let childKeys = Object.keys(curType.getFields() || {});
         childQuery = childKeys
           .filter((fieldName) => {
             /* Exclude deprecated fields */
@@ -282,7 +290,7 @@ module.exports = {
           for (let i = 0, len = types.length; i < len; i++) {
             const valueTypeName = types[i],
               valueType = gqlSchema.getType(valueTypeName),
-              unionChildQuery = Object.keys(valueType.getFields())
+              unionChildQuery = Object.keys(valueType.getFields() || {})
                 .map((cur) => {
                   // Don't genrate query fields that have self referencing
                   if (cur === curName) {
@@ -330,7 +338,7 @@ module.exports = {
           console.log('[gqlg warning]:', 'description is required');
       }
 
-      Object.keys(obj).forEach((type) => {
+      typeof obj === 'object' && Object.keys(obj).forEach((type) => {
 
         let field,
           newDescription;
@@ -358,9 +366,12 @@ module.exports = {
 
           /* Generate variables Object from argumentDict */
           var variables = {};
-          Object.entries(queryResult.argumentsDict).map(([varName, arg]) => {
-            variables[varName] = resolveVariableType(arg.type, gqlSchema, 0, stackLimit);
-          });
+
+          if (typeof queryResult.argumentsDict === 'object') {
+            Object.entries(queryResult.argumentsDict).map(([varName, arg]) => {
+              variables[varName] = resolveVariableType(arg.type, gqlSchema, 0, stackLimit);
+            });
+          }
 
           let query = queryResult.queryStr;
           // here the `description` is used to construct the actual queries

--- a/test/unit/gql-generator.test.js
+++ b/test/unit/gql-generator.test.js
@@ -22,4 +22,21 @@ describe('gql-generator tests', function () {
 
     done();
   });
+
+  it('should not throw type error for some of elements that are defined non-object in GQL schema', function (done) {
+    const data = validSchemaSDL,
+      gqlSchemaObj = graphql.buildSchema(data);
+
+    // Set specific property as null to test behaviour for non defined nodes.
+    gqlSchemaObj._mutationType._fields = undefined;
+
+    try {
+      schemaToQuery(gqlSchemaObj);
+    }
+    catch (e) {
+      expect(e).to.be.undefined;
+    }
+
+    done();
+  });
 });


### PR DESCRIPTION
## Overview

This PR fixes certain issue that resulted in TypeError in certain edge cases. Aim is to gracefully handle such errors and not throw TypeError. With this fix, we'll not generate variables or queries which has issues rather than entire collection generation failing.