### PR TITLE
Fixed an issue where GQL definition of having Union self refs past depth limit was failing with RangeError.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,23 @@
-name: Tests
+name: Test
 
 on:
-  [pull_request]
+  push:
+    branches: [develop, master]
+  pull_request:
 
 jobs:
   Unit-Tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - run: npm run test
+      - run: npm run test-lint
+      - run: npm run test-system
+      - run: npm run test-unit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,4 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run test-lint
-      - run: npm run test-system
       - run: npm run test-unit

--- a/lib/assets/gql-generator.js
+++ b/lib/assets/gql-generator.js
@@ -281,6 +281,16 @@ module.exports = {
 
       /* Union types */
       if (curType.astNode && curType.astNode.kind === 'UnionTypeDefinition') {
+
+        /* Make sure UnionTypeDefinition are also not circularly referenced */
+        if ((crossReferenceKeyList.hasOwnProperty(crossReferenceKey) && crossReferenceKeyList[crossReferenceKey]) ||
+          curDepth > depthLimit
+        ) {
+          crossReferenceKeyList[crossReferenceKey] = false;
+          return '';
+        }
+        crossReferenceKeyList[crossReferenceKey] = true;
+
         const types = curType.getTypes();
         if (types && types.length) {
           const indent = `${'    '.repeat(curDepth)}`,

--- a/test/unit/fixtures/seflRefDepthUnionSchema.graphql
+++ b/test/unit/fixtures/seflRefDepthUnionSchema.graphql
@@ -1,0 +1,30 @@
+# A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+scalar DateTime
+
+type Organization {
+  id: ID!
+  createdBy: User!
+  updatedBy: User!
+  name: String!
+  avatarUrl: String
+  owner: String!
+}
+
+# User
+type User {
+  id: ID!
+  organization: OrganizationOrStringUnion
+  idpId: String!
+  firstName: String!
+  lastName: String!
+  createdBy: UserOrStringUnion
+  updatedBy: UserOrStringUnion
+}
+
+union OrganizationOrStringUnion = Organization
+
+union UserOrStringUnion = User
+
+type Query {
+  User(id: String!): User!
+}


### PR DESCRIPTION
## Overview

This PR fixes issue where definitions having UnionType self-referencing itself past depth limit were not converted correctly. Such conversion was failing with following RangeError.

```
Could not generate collection. Error Message:Maximum call stack size exceeded
```

## Fix

We'll be making sure that any self referencing union types past provided depth limit will be resolved correctly with correct comment mentioning the reason like below.

```
# self reference detected
# skipping "createdBy"
```