### PR TITLE
chore: Bump grapqhl package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "2.20.3",
-        "graphql": "14.5.8",
+        "graphql": "15.8.0",
         "lodash": "4.17.19",
         "postman-collection": "3.5.5"
       },
@@ -1587,14 +1587,11 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "14.5.8",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.5.8.tgz",
-      "integrity": "sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==",
-      "dependencies": {
-        "iterall": "^1.2.2"
-      },
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "engines": {
-        "node": ">= 6.x"
+        "node": ">= 10.x"
       }
     },
     "node_modules/growl": {
@@ -2132,11 +2129,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/iterall": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
-      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
     },
     "node_modules/js-tokens": {
       "version": "3.0.2",
@@ -5537,12 +5529,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "14.5.8",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.5.8.tgz",
-      "integrity": "sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==",
-      "requires": {
-        "iterall": "^1.2.2"
-      }
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw=="
     },
     "growl": {
       "version": "1.10.5",
@@ -5971,11 +5960,6 @@
       "requires": {
         "handlebars": "^4.1.2"
       }
-    },
-    "iterall": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
-      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
     },
     "js-tokens": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "commander": "2.20.3",
-    "graphql": "14.5.8",
+    "graphql": "15.8.0",
     "lodash": "4.17.19",
     "postman-collection": "3.5.5"
   },


### PR DESCRIPTION
Bumping up the graphql package version to match the version used by `postman-app`. Based on the graphql 15.0.0 [release notes](https://github.com/graphql/graphql-js/releases/tag/v15.0.0-alpha.1) it seems like there shouldn't be any breaking changes that impact the functionality of this package. Additionally all tests are currently passing, but manual testing is still needed.